### PR TITLE
Technic Plus compatibility (minimal)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -226,7 +226,9 @@ minetest.register_tool("technic_grass_clean:grass_cleaner", {
 			return itemstack
 		end
 
-		local meta = minetest.deserialize(itemstack:get_metadata())
+		local meta = technic.plus
+			and { charge = technic.get_RE_charge(itemstack) }
+			or minetest.deserialize(itemstack:get_metadata())
 		if not meta or not meta.charge or
 				meta.charge < chainsaw_charge_per_node then
 			return


### PR DESCRIPTION
Minimal compatibility for Technic Plus.

See also full compatibility option #2, this PR is for minimal changes with some drawbacks.

This will keep complaining about deprecated ItemStack functions and Technic Plus will also complain about deprecated power tool API.
Also will keep serializing and writing unnecessary itemstack metadata when using Technic Plus.